### PR TITLE
feat: create channels

### DIFF
--- a/src/channel/channel.controller.ts
+++ b/src/channel/channel.controller.ts
@@ -1,7 +1,13 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
 import { ChannelService } from './channel.service';
+import { ChannelRequestDto } from './dto';
 
 @Controller('v1/channel')
 export class ChannelController {
   constructor(private readonly channelService: ChannelService) { }
+
+  @Post()
+  async createChannel(@Body() channel: ChannelRequestDto) {
+    return this.channelService.createChannel(channel);
+  }
 }

--- a/src/channel/channel.module.ts
+++ b/src/channel/channel.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
-import { ChannelService } from './channel.service';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Channel, ChannelSchema } from 'src/schemas/channel.model';
 import { ChannelController } from './channel.controller';
+import { ChannelService } from './channel.service';
 
 @Module({
-  providers: [ChannelService],
-  controllers: [ChannelController]
+  imports: [
+    MongooseModule.forFeature([{ name: Channel.name, schema: ChannelSchema }]),
+  ],
+  providers: [ChannelService, MongooseModule],
+  controllers: [ChannelController],
 })
-export class ChannelModule {}
+export class ChannelModule { }

--- a/src/channel/channel.service.ts
+++ b/src/channel/channel.service.ts
@@ -1,10 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, InternalServerErrorException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
+import { ValidationError } from 'class-validator';
 import { Channel } from 'diagnostics_channel';
 import { Model } from 'mongoose';
 import { ChannelDocument } from 'src/schemas/channel.model';
+import { ChannelRequestDto } from './dto';
 
 @Injectable()
 export class ChannelService {
   constructor(@InjectModel(Channel.name) private channelModel: Model<ChannelDocument>) { }
+
+  async createChannel(channel: ChannelRequestDto) {
+    try {
+      var response = await this.channelModel.create(channel);
+    } catch (error) {
+      if (error.name === 'ValidationError') {
+        throw new BadRequestException(error._message);
+      }
+    }
+
+    return response;
+  }
 }

--- a/src/channel/dto/channel.dto.ts
+++ b/src/channel/dto/channel.dto.ts
@@ -1,0 +1,28 @@
+import { Expose } from "class-transformer";
+import { ArrayMinSize, IsArray, IsNotEmpty, IsOptional, IsString, IsUrl, Length, MinLength } from "class-validator";
+
+export class ChannelRequestDto {
+  @IsString({ message: 'Name must be a string' })
+  @IsNotEmpty({ message: 'Name is required' })
+  name: string;
+
+  @IsString({ message: 'Description must be a string' })
+  @IsOptional()
+  description: string;
+
+  @IsString({ message: 'Image URL must be a string' })
+  @IsUrl({}, { message: 'Image URL must be a valid URL' })
+  @Expose({ name: 'image_url' })
+  @IsOptional()
+  imageUrl: string;
+
+  @IsArray()
+  @IsNotEmpty({ message: 'Members are required' })
+  @ArrayMinSize(4, { message: 'Members must have at least 4 members' })
+  members: string[];
+
+  @IsArray()
+  @IsNotEmpty({ message: 'Admins are required' })
+  @ArrayMinSize(4, { message: 'Admins must have at least 4 admin' })
+  admins: string[];
+}

--- a/src/channel/dto/index.ts
+++ b/src/channel/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './channel.dto';

--- a/src/schemas/channel.model.ts
+++ b/src/schemas/channel.model.ts
@@ -1,4 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Expose } from 'class-transformer';
 import * as mongoose from "mongoose";
 
 export type ChannelDocument = mongoose.HydratedDocument<Channel>;
@@ -14,7 +15,7 @@ export class Channel {
   @Prop({ required: true })
   name: string;
 
-  @Prop({ required: true })
+  @Prop({ default: "" })
   description: string;
 
   @Prop({ required: true, type: [mongoose.Schema.Types.ObjectId], ref: 'User' })


### PR DESCRIPTION
This pull request introduces several changes to the `channel` module of the application. The primary focus of these changes is to add a new feature that allows the creation of channels. This feature has been implemented by adding a new POST endpoint to the `ChannelController`, and the corresponding service method in `ChannelService`. To support this, a new `ChannelRequestDto` has been defined to validate the incoming request payload. The `ChannelModule` has been updated to include `MongooseModule` for MongoDB interactions. Lastly, the `Channel` schema has been updated to make the `description` field optional.

Here are the most important changes:

Addition of new endpoint and service method:

* [`src/channel/channel.controller.ts`](diffhunk://#diff-70a10ffe7564131e69f731d25282540912554cd4b6c7d43090eb30014720dce4L1-R12): Added a new POST endpoint to create a channel. This endpoint uses the `ChannelRequestDto` to validate the request payload.
* [`src/channel/channel.service.ts`](diffhunk://#diff-b58c1f58ee7b4de7b856d663463ea8ff00bdd8e5fac0b90e00ed458e33042e16L1-R23): Added a new `createChannel` service method that interacts with the MongoDB database using Mongoose. It also handles `ValidationError` exceptions.

Introduction of new DTO:

* [`src/channel/dto/channel.dto.ts`](diffhunk://#diff-d74e649d6fe925708d38347e48c5163011f1902a4a1aa3810e2671e609a78dceR1-R28): Defined a new `ChannelRequestDto` class that uses decorators from `class-validator` to validate the incoming request payload.
* [`src/channel/dto/index.ts`](diffhunk://#diff-4d696760154f40ba611c052ad18fe9837aa4a63d72c553b5e6635251d21de61dR1): Exported the `ChannelRequestDto` class for use in other modules.

Updates to the module and schema:

* [`src/channel/channel.module.ts`](diffhunk://#diff-4db3b6612fa224295dc29afa38bec730fb175cb71562f53ccea4dd1dcaa0f793L2-R12): Imported `MongooseModule` and added it to the `providers` array to enable MongoDB interactions.
* [`src/schemas/channel.model.ts`](diffhunk://#diff-bcc86346dbe2b57d1df191b76897eafe9c9dfd021321f8c9796c83dc1720c198L17-R18): Updated the `Channel` schema to make the `description` field optional.